### PR TITLE
Add ScholarMarkdown to the list of tools

### DIFF
--- a/iswc-2019.html
+++ b/iswc-2019.html
@@ -107,6 +107,26 @@
                   <p>If you choose to write HTML/RASH manually (which makes sense when collaborating with your co-authors in a source code repository), note that the above-mentioned <a href="http://dasplab.cs.unibo.it/rocs">ROCS</a> can actually convert <em>any</em> RASH markup to LaTeX.</p>
                 </div>
               </section>
+
+              <section id="scholarmarkdown" inlist="" rel="schema:hasPart" resource="scholarmarkdown">
+                <h3 proprety="schema:name">ScholarMarkdown</h3>
+                <div property="schema:description">
+                  <p>
+                      <a href="https://github.com/rubensworks/ScholarMarkdown">ScholarMarkdown</a> is framework for writing articles in the lightweight Markdown syntax, with automatic translation into HTML+RDFa, and the option to output <a href="https://github.com/rubensworks/ScholarMarkdown/wiki/PDF-Compilation">PDF</a>.
+                      It provides syntactic sugar to easily perform common tasks such as <a href="https://github.com/rubensworks/ScholarMarkdown/wiki/Snippets#citations">citing articles</a>, writing <a href="https://github.com/rubensworks/ScholarMarkdown/wiki/Snippets#math-equations">math equations</a>, and <a href="https://github.com/rubensworks/ScholarMarkdown/wiki/Snippets">more</a>.
+                  </p>
+                  
+                  <p><b>Note: ScholarMarkdown requires <a href="https://www.ruby-lang.org/en/documentation/installation/">Ruby</a> to be installed.</b></p>
+                  
+                  <p>
+                      The Markdown-based source files enables straightforward versioning and collaborative editing with version-control systems such as git,
+                      and integrates nicely with automated <a href="https://github.com/rubensworks/ScholarMarkdown/wiki/Self-publishing">self-publishing via solutions such as GitHub pages</a>,
+                      as demonstrated by the <a href="https://github.com/rubensworks/ScholarMarkdown/wiki/Examples">examples in the wild</a>.
+                  </p>
+
+                  <p>To get started, follow the <a href="https://github.com/rubensworks/ScholarMarkdown#quick-start">quick start guide</a>, which will provide you with the the required LNCS template in Markdown. Further details can be found on the <a href="https://github.com/rubensworks/ScholarMarkdown/wiki">wiki</a>.</p>
+                </div>
+              </section>
             </div>
           </section>
 


### PR DESCRIPTION
This adds [ScholarMarkdown](https://github.com/rubensworks/ScholarMarkdown) to the list of tools to write HTML articles.